### PR TITLE
Create jwt.py for frontend auth

### DIFF
--- a/meowtopia/backend/app/auth/__init__.py
+++ b/meowtopia/backend/app/auth/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+from .routes import router as _routes
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+router.include_router(_routes)
+

--- a/meowtopia/backend/app/auth/config.py
+++ b/meowtopia/backend/app/auth/config.py
@@ -1,0 +1,11 @@
+from datetime import timedelta
+import os
+
+SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-secret-change-me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
+
+
+def get_access_token_expiry_delta() -> timedelta:
+    return timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+

--- a/meowtopia/backend/app/auth/deps.py
+++ b/meowtopia/backend/app/auth/deps.py
@@ -1,0 +1,40 @@
+from typing import Dict, Any
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+from .config import SECRET_KEY, ALGORITHM
+from .security import security
+from .store import USERS_BY_EMAIL
+
+
+def verify_token(token: str) -> Dict[str, Any]:
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def get_current_user_payload(credentials: HTTPAuthorizationCredentials = Depends(security)) -> Dict[str, Any]:
+    return verify_token(credentials.credentials)
+
+
+def get_user_or_404(email: str) -> Dict[str, Any]:
+    user = USERS_BY_EMAIL.get(email.lower())
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+def require_role(required_role: str):
+    def role_checker(payload: Dict[str, Any] = Depends(get_current_user_payload)) -> Dict[str, Any]:
+        role = payload.get("role", "user")
+        if role != required_role and role != "admin":
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return payload
+    return role_checker
+

--- a/meowtopia/backend/app/auth/jwt.py
+++ b/meowtopia/backend/app/auth/jwt.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+from .routes import router as _routes
+
+# Backward-compatible router export under the same filename
+router = APIRouter(prefix="/auth", tags=["auth"])
+router.include_router(_routes)
+

--- a/meowtopia/backend/app/auth/routes/__init__.py
+++ b/meowtopia/backend/app/auth/routes/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from .register import router as register_router
+from .login import router as login_router
+from .password import router as password_router
+from .email import router as email_router
+from .twofa import router as twofa_router
+from .me import router as me_router
+
+router = APIRouter()
+router.include_router(register_router)
+router.include_router(login_router)
+router.include_router(password_router)
+router.include_router(email_router)
+router.include_router(twofa_router)
+router.include_router(me_router)
+

--- a/meowtopia/backend/app/auth/routes/email.py
+++ b/meowtopia/backend/app/auth/routes/email.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, HTTPException
+from ..store import USERS_BY_EMAIL
+from ..schemas import ConfirmEmailRequest
+
+router = APIRouter()
+
+
+@router.post("/confirm-email")
+def confirm_email(req: ConfirmEmailRequest):
+    for user in USERS_BY_EMAIL.values():
+        if req.token in user["confirm_tokens"]:
+            user["is_email_confirmed"] = True
+            user["confirm_tokens"].discard(req.token)
+            return {"message": "Email confirmed"}
+    raise HTTPException(status_code=400, detail="Invalid or expired confirmation token")
+

--- a/meowtopia/backend/app/auth/routes/login.py
+++ b/meowtopia/backend/app/auth/routes/login.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta
+from fastapi import APIRouter, HTTPException
+from jose import jwt
+import secrets
+
+try:
+    import pyotp
+except Exception:
+    pyotp = None
+
+from ..config import SECRET_KEY, ALGORITHM, get_access_token_expiry_delta
+from ..security import verify_password
+from ..store import USERS_BY_EMAIL, TWOFA_TEMP_TOKENS
+from ..schemas import LoginRequest, TokenResponse
+
+router = APIRouter()
+
+
+def create_access_token(data: dict) -> str:
+    to_encode = data.copy()
+    to_encode.update({"exp": datetime.utcnow() + get_access_token_expiry_delta()})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+@router.post("/login", response_model=TokenResponse)
+def login(req: LoginRequest):
+    user = USERS_BY_EMAIL.get(req.email.lower())
+    if not user or not verify_password(req.password, user["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    if not user["is_email_confirmed"]:
+        raise HTTPException(status_code=403, detail="Email not confirmed")
+
+    if user["twofa_enabled"]:
+        if not req.twofa_code:
+            temp_token = secrets.token_urlsafe(32)
+            TWOFA_TEMP_TOKENS[temp_token] = {"email": user["email"], "exp": datetime.utcnow() + timedelta(minutes=5)}
+            return TokenResponse(requires_2fa=True, temp_token=temp_token)
+
+        if not pyotp or not user["twofa_secret"]:
+            raise HTTPException(status_code=500, detail="2FA not available")
+
+        totp = pyotp.TOTP(user["twofa_secret"])
+        if not totp.verify(req.twofa_code, valid_window=1):
+            raise HTTPException(status_code=401, detail="Invalid 2FA code")
+
+    token = create_access_token(
+        {"sub": user["email"], "role": user["role"], "user_id": user["id"], "twofa_enabled": user["twofa_enabled"]}
+    )
+    return TokenResponse(access_token=token)
+

--- a/meowtopia/backend/app/auth/routes/me.py
+++ b/meowtopia/backend/app/auth/routes/me.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from ..deps import get_current_user_payload, get_user_or_404
+
+router = APIRouter()
+
+
+@router.get("/me")
+def me(payload = Depends(get_current_user_payload)):
+    email = payload.get("sub")
+    user = get_user_or_404(email)
+    return {
+        "id": user["id"],
+        "email": user["email"],
+        "role": user["role"],
+        "is_email_confirmed": user["is_email_confirmed"],
+        "twofa_enabled": user["twofa_enabled"],
+    }
+

--- a/meowtopia/backend/app/auth/routes/password.py
+++ b/meowtopia/backend/app/auth/routes/password.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException, Depends
+import secrets
+
+from ..security import get_password_hash, verify_password
+from ..store import USERS_BY_EMAIL
+from ..deps import get_current_user_payload, get_user_or_404
+from ..schemas import ForgotPasswordRequest, ResetPasswordRequest, ChangePasswordRequest
+
+router = APIRouter()
+
+
+@router.post("/forgot-password")
+def forgot_password(req: ForgotPasswordRequest):
+    user = USERS_BY_EMAIL.get(req.email.lower())
+    reset_token = None
+    if user:
+        reset_token = secrets.token_urlsafe(32)
+        user["reset_tokens"].add(reset_token)
+    return {
+        "message": "If the email exists, a reset link has been sent.",
+        "reset_token": reset_token,
+    }
+
+
+@router.post("/reset-password")
+def reset_password(req: ResetPasswordRequest):
+    for user in USERS_BY_EMAIL.values():
+        if req.token in user["reset_tokens"]:
+            user["password_hash"] = get_password_hash(req.new_password)
+            user["reset_tokens"].discard(req.token)
+            return {"message": "Password updated"}
+    raise HTTPException(status_code=400, detail="Invalid or expired reset token")
+
+
+@router.post("/change-password")
+def change_password(req: ChangePasswordRequest, payload = Depends(get_current_user_payload)):
+    email = payload.get("sub")
+    user = get_user_or_404(email)
+    if not verify_password(req.old_password, user["password_hash"]):
+        raise HTTPException(status_code=401, detail="Incorrect current password")
+    user["password_hash"] = get_password_hash(req.new_password)
+    return {"message": "Password changed"}
+

--- a/meowtopia/backend/app/auth/routes/register.py
+++ b/meowtopia/backend/app/auth/routes/register.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, HTTPException
+import secrets
+
+from ..security import get_password_hash
+from ..store import USERS_BY_EMAIL
+from ..schemas import RegisterRequest
+
+router = APIRouter()
+
+
+@router.post("/register")
+def register(req: RegisterRequest):
+    email_key = req.email.lower()
+    if email_key in USERS_BY_EMAIL:
+        raise HTTPException(status_code=400, detail="User already exists")
+
+    user_id = secrets.token_hex(8)
+    password_hash = get_password_hash(req.password)
+    user = {
+        "id": user_id,
+        "email": email_key,
+        "password_hash": password_hash,
+        "role": "user",
+        "is_email_confirmed": False,
+        "twofa_enabled": False,
+        "twofa_secret": None,
+        "confirm_tokens": set(),
+        "reset_tokens": set(),
+    }
+
+    confirm_token = secrets.token_urlsafe(32)
+    user["confirm_tokens"].add(confirm_token)
+    USERS_BY_EMAIL[email_key] = user
+
+    return {
+        "message": "User registered. Please confirm your email.",
+        "confirm_token": confirm_token,
+        "user_id": user_id,
+    }
+

--- a/meowtopia/backend/app/auth/routes/twofa.py
+++ b/meowtopia/backend/app/auth/routes/twofa.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, HTTPException, Depends
+try:
+    import pyotp
+except Exception:
+    pyotp = None
+
+from ..deps import get_current_user_payload, get_user_or_404
+from ..store import TWOFA_TEMP_TOKENS
+from ..schemas import TwoFAInitResponse, TwoFAVerifyRequest
+from ..config import SECRET_KEY, ALGORITHM, get_access_token_expiry_delta
+from jose import jwt
+from datetime import datetime
+
+router = APIRouter()
+
+
+def create_access_token(data: dict) -> str:
+    to_encode = data.copy()
+    to_encode.update({"exp": datetime.utcnow() + get_access_token_expiry_delta()})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+@router.post("/2fa/initiate", response_model=TwoFAInitResponse)
+def twofa_initiate(payload = Depends(get_current_user_payload)):
+    if not pyotp:
+        raise HTTPException(status_code=500, detail="pyotp is required for 2FA; please install it")
+
+    email = payload.get("sub")
+    user = get_user_or_404(email)
+
+    if user["twofa_enabled"] and user["twofa_secret"]:
+        totp = pyotp.TOTP(user["twofa_secret"])
+        return TwoFAInitResponse(secret=user["twofa_secret"], otpauth_url=totp.provisioning_uri(name=email, issuer_name="Meowtopia"))
+
+    secret = pyotp.random_base32()
+    user["twofa_secret"] = secret
+    totp = pyotp.TOTP(secret)
+    return TwoFAInitResponse(secret=secret, otpauth_url=totp.provisioning_uri(name=email, issuer_name="Meowtopia"))
+
+
+@router.post("/2fa/verify")
+def twofa_verify(req: TwoFAVerifyRequest, maybe_payload = Depends(lambda: None)):
+    if req.temp_token:
+        challenge = TWOFA_TEMP_TOKENS.get(req.temp_token)
+        if not challenge or challenge["exp"] < datetime.utcnow():
+            raise HTTPException(status_code=400, detail="Invalid or expired 2FA challenge")
+        email = challenge["email"]
+        user = get_user_or_404(email)
+        if not pyotp or not user["twofa_secret"]:
+            raise HTTPException(status_code=500, detail="2FA not available")
+        totp = pyotp.TOTP(user["twofa_secret"])
+        if not totp.verify(req.code, valid_window=1):
+            raise HTTPException(status_code=401, detail="Invalid 2FA code")
+        TWOFA_TEMP_TOKENS.pop(req.temp_token, None)
+        token = create_access_token(
+            {"sub": user["email"], "role": user["role"], "user_id": user["id"], "twofa_enabled": True}
+        )
+        return {"message": "2FA verification successful", "access_token": token, "token_type": "bearer"}
+
+    if maybe_payload is None:
+        raise HTTPException(status_code=401, detail="Authorization required")
+    email = maybe_payload.get("sub")
+    user = get_user_or_404(email)
+    if not pyotp or not user["twofa_secret"]:
+        raise HTTPException(status_code=500, detail="2FA not available")
+    totp = pyotp.TOTP(user["twofa_secret"])
+    if not totp.verify(req.code, valid_window=1):
+        raise HTTPException(status_code=401, detail="Invalid 2FA code")
+    user["twofa_enabled"] = True
+    return {"message": "2FA enabled"}
+

--- a/meowtopia/backend/app/auth/schemas.py
+++ b/meowtopia/backend/app/auth/schemas.py
@@ -1,0 +1,49 @@
+from typing import Optional, Literal
+from pydantic import BaseModel, EmailStr, Field
+
+
+class TokenResponse(BaseModel):
+    access_token: Optional[str] = None
+    token_type: Literal["bearer"] = "bearer"
+    requires_2fa: Optional[bool] = None
+    temp_token: Optional[str] = None
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=6, max_length=128)
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+    twofa_code: Optional[str] = None
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str = Field(min_length=6, max_length=128)
+
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str
+    new_password: str = Field(min_length=6, max_length=128)
+
+
+class ConfirmEmailRequest(BaseModel):
+    token: str
+
+
+class TwoFAInitResponse(BaseModel):
+    secret: str
+    otpauth_url: Optional[str] = None
+
+
+class TwoFAVerifyRequest(BaseModel):
+    code: str
+    temp_token: Optional[str] = None
+

--- a/meowtopia/backend/app/auth/security.py
+++ b/meowtopia/backend/app/auth/security.py
@@ -1,0 +1,14 @@
+from fastapi.security import HTTPBearer
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+security = HTTPBearer()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+

--- a/meowtopia/backend/app/auth/store.py
+++ b/meowtopia/backend/app/auth/store.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from typing import Dict, Any
+
+# In-memory store for demo/dev. Replace with a DB in production.
+# user shape documented in original monolithic file
+USERS_BY_EMAIL: Dict[str, Dict[str, Any]] = {}
+
+# temp 2FA challenges: token -> {"email": str, "exp": datetime}
+TWOFA_TEMP_TOKENS: Dict[str, Dict[str, Any]] = {}
+


### PR DESCRIPTION
Refactor monolithic `jwt.py` into modular files under `auth/` to improve code organization and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-f72c6639-6df1-491c-a43e-60bf4f5c0616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f72c6639-6df1-491c-a43e-60bf4f5c0616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

